### PR TITLE
Add support for filtering on getCategories()

### DIFF
--- a/src/DesignsClient.php
+++ b/src/DesignsClient.php
@@ -118,10 +118,18 @@ class DesignsClient extends Affinity
         return json_decode($res->getBody()->getContents(), true);
     }
 
-    public function getCategories()
+    /**
+     * Returns a list of product categories
+     *
+     * Supports passing additional filter params, i.e., "'licensed' => 1"
+     * @see http://apidocs.affinitygateway.com/#operation/listCategories
+     * @param array $params key/value pairs of additional params
+     * @return array Product categories listing
+     */
+    public function getCategories(array $params = [])
     {
         $path = '/product_categories';
-        $res = $this->client->request('GET', $path);
+        $res = $this->client->request('GET', $path, ['query' => $params]);
 
         if ($res->getStatusCode() !== 200) {
             $this->throwInvalidResponseException($res);

--- a/tests/Affinity/ListCategoriesTest.php
+++ b/tests/Affinity/ListCategoriesTest.php
@@ -36,6 +36,16 @@ class ListCategoriesTest extends DesignsTestCase
     }
 
     /** @test */
+    public function request_includes_parameters()
+    {
+        $this->designs->getCategories(['is_available' => true]);
+
+        $request = $this->historyContainer[0]['request'];
+
+        $this->assertEquals('is_available=1', $request->getUri()->getQuery());
+    }
+
+    /** @test */
     public function throws_exception_on_non_200_response()
     {
         $handler = $this->getCustomMockHandler(500, ['message' => 'It broke']);


### PR DESCRIPTION
Support for filtering product categories to those the vendor
is licensed for was added to the api. The change here makes this
usable by this client implementation.

Corresponds to https://github.com/affinitylicensing/api/issues/319.